### PR TITLE
Add QA dependency guide

### DIFF
--- a/source/install.rst
+++ b/source/install.rst
@@ -20,6 +20,7 @@ Get dependencies
 ----------------
 
 Get robosherlock_msgs. This is a ROS package and needs to be checked out in your catkin workspace. ::
+
 	git clone git@github.com:RoboSherlock/robosherlock_msgs.git
 
 The following packages should be installed(This will add the RoboSherlock PPA to your software sources): ::
@@ -76,3 +77,17 @@ Check out :ref:`pipeline`
 for details about how to run a small demo.
 
 
+Installing and Running the query-answering
+-----------------------------------------
+In order to use the query-answering capabilities of RoboSherlock, the following libraries need to be installed:
+
+
+Knowrob: Follow the official Installation guide for the Knowrob Installation, which can be found on their installation page_.
+
+.. _page: http://www.knowrob.org/installation
+
+Robosherlock_knowrob: Check out the repository into your workspace. ::
+
+   git clone https://github.com/RoboSherlock/robosherlock_knowrob.git
+
+Check out :ref:`write_queries` for details about how to use the query-answering.

--- a/source/tutorials/write_queries.rst
+++ b/source/tutorials/write_queries.rst
@@ -4,7 +4,11 @@
 Use queries to control the pipeline
 ===================================
 
-This tutorial assumes that the reader has started RoboSherlock, downloaded the bag file available in the :ref:`first tutorial<pipeline>` and loaded the bagfile into the MongoDB as described in the :ref:`tutorial about logging results<mongodb>`. 
+This tutorial assumes that the reader has followed the installation guide, which can be found here :ref:`install_rs`, including the installation of the query-answering dependencies. The reader should also have started RoboSherlock, downloaded the bag file available in the :ref:`first tutorial<pipeline>` and loaded the bagfile into the MongoDB as described in the :ref:`tutorial about logging results<mongodb>`. 
+
+Before using queries in robosherlock, json_prolog needs to be started as follows.::
+
+	roslaunch json_prolog json_prolog.launch _initial_package:=robosherlock_knowrob
 
 RoboSherlock supports querying for certain characteristics, which it will try to perceive in the scene.
 As an example, the user may want to know, whether there are any blue objects in the scene.


### PR DESCRIPTION
This pull request adds an installation guide for the dependencies required by the query answering part of RoboSherlock.